### PR TITLE
Fix a misspelled word in german translation

### DIFF
--- a/german.json
+++ b/german.json
@@ -339,7 +339,7 @@
     "Export Matches": "Export Matches",
     "Export Method": "Export Method",
     "eXtra": "eXtra",
-    "Favorite Regex": "Regex ffavorisieren",
+    "Favorite Regex": "Regex favorisieren",
     "Feel free to refresh the page and try again later, the offline version will remain available to you.": "Feel free to refresh the page and try again later, the offline version will remain available to you.",
     "Filter by Flavor": "Filtern nach Regex Variante",
     "Find out what's new!": "Find out what's new!",


### PR DESCRIPTION
I corrected `ffavorisieren` to `favorisieren` .